### PR TITLE
Dataframe improvements and search adjustment

### DIFF
--- a/search_list.csv
+++ b/search_list.csv
@@ -1,10 +1,10 @@
 search_name,game,channel_id,channel_search_regex
 TNS Tekken 8,TEKKEN 8,UCu6S7Z0ln2llqNTLhRKFxJA,TEKKEN 8
-TNS SF6,Street Fighter 6,UCu6S7Z0ln2llqNTLhRKFxJA,Street Fighter 6
+TNS SF6,Street Fighter 6,UCu6S7Z0ln2llqNTLhRKFxJA,(Street Fighter 6|SF6)
 TNS GBVSR,Granblue Fantasy Versus Rising,UCu6S7Z0ln2llqNTLhRKFxJA,(?=.*Granblue)(?=.*Rising)
 TNS GGST,Guilty Gear Strive,UCu6S7Z0ln2llqNTLhRKFxJA,(?=.*Guilty)(?=.*Gear)(?=.*Strive)
 Spooky Tekken 8,TEKKEN 8,UCjT9Hwh4twdfvFZCV1tIsCw,Tekken 8.*(Pools|Top 6|Top 8|Top 16|Top 24|Top 32)
-Spooky SF6,Street Fighter 6,UCjT9Hwh4twdfvFZCV1tIsCw,Street Fighter 6.*(Pools|Top 6|Top 8|Top 16|Top 24|Top 32)
+Spooky SF6,Street Fighter 6,UCjT9Hwh4twdfvFZCV1tIsCw,(Street Fighter 6|SF6).*(Pools|Top 6|Top 8|Top 16|Top 24|Top 32)
 Spooky GBVSR,Granblue Fantasy Versus Rising,UCjT9Hwh4twdfvFZCV1tIsCw,(?=.*Granblue)(?=.*Rising).*(Pools|Top 6|Top 8|Top 16|Top 24|Top 32)
 Spooky GGST,Guilty Gear Strive,UCjT9Hwh4twdfvFZCV1tIsCw,(?=.*Guilty)(?=.*Gear)(?=.*Strive).*(Pools|Top 6|Top 8|Top 16|Top 24|Top 32)
 BNE Tekken 8,TEKKEN 8,UCKHx_yf3dI2ajWAjXRJ_9Rw,TWT 2024


### PR DESCRIPTION
Sadly there isn't a great way to have custom text links in streamlit, which is kind of wild. So I just kept the link column, made it static text, and moved it first. It now looks like `Open Match |  Player1 (Character1) vs Player2 (Character 2)`, which I still think is an improvement. Sorting is also improved.

I also added "SF6" to the "Street Fighter 6" searches.

closes #3 