### PR TITLE
add vid none check

### DIFF
--- a/update_database.py
+++ b/update_database.py
@@ -19,6 +19,8 @@ def scrape_videos(channel_id: str, title_regex: str) -> list[dict]:
 def update_database(videos: list, game: str, conn: sqlite3.Connection) -> None:
     """ Given a list of videos, extract match info and update the database. """
     for vid in videos:
+        if vid is None:
+            continue
         for chapter in vid["chapters"] if vid["chapters"] else []:
             if "vs" not in chapter["title"]:
                 continue


### PR DESCRIPTION
For some reason youtubedl playlist entries can be None, and it *sometimes* causes a crash. So, I added a simple none check.

This worked once, surely it will always work :)

closes #1 